### PR TITLE
Add project Website links to two reading-goals papers

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,6 +152,7 @@
                 <a target="_blank" rel="noopener noreferrer" href="https://openreview.net/pdf?id=fHr1uqkdsb">PDF</a>
                 <a target="_blank" rel="noopener noreferrer" href="https://openreview.net/forum?id=fHr1uqkdsb">OpenReview</a>
                 <a target="_blank" rel="noopener noreferrer" href="https://github.com/lacclab/Open-Ended-Goal-Decoding">Code</a>
+                <a target="_blank" rel="noopener noreferrer" href="https://lacclab.github.io/Open-Ended-Goal-Decoding-Landing/">Website</a>
                 <a href="javascript:void(0)" onclick="toggleSection('abs-hadar2026')">Abstract</a>
                 <a href="javascript:void(0)" onclick="toggleSection('cite-hadar2026')">BIB</a>
               </div>
@@ -228,6 +229,7 @@
               <div class="pub-links">
                 <a target="_blank" rel="noopener noreferrer" href="https://aclanthology.org/2025.acl-long.280.pdf">PDF</a>
                 <a target="_blank" rel="noopener noreferrer" href="https://github.com/lacclab/Goal-Decoding-from-Eye-Movements">Code</a>
+                <a target="_blank" rel="noopener noreferrer" href="https://lacclab.github.io/Decoding-Reading-Goals-from-Eye-Movements-Landing/">Website</a>
                 <a href="javascript:void(0)" onclick="toggleSection('abs-shubi2025goals')">Abstract</a>
                 <a href="javascript:void(0)" onclick="toggleSection('cite-shubi2025goals')">BIB</a>
               </div>


### PR DESCRIPTION
## Summary

The EyeBench (NeurIPS 2025) and OneStop (Scientific Data 2025) entries already link to their project landing pages via a `Website` link in their `pub-links` row. The Hadar 2026 (ICLR) and Shubi 2025 goals (ACL) entries now have landing pages too — wire them up the same way.

- `hadar2026` → https://lacclab.github.io/Open-Ended-Goal-Decoding-Landing/
- `shubi2025goals` → https://lacclab.github.io/Decoding-Reading-Goals-from-Eye-Movements-Landing/

## Files changed

- `index.html` — two new `<a … >Website</a>` links inserted next to the existing `Code` link in each entry, mirroring the existing EyeBench / OneStop pattern

## Test plan

- [x] Verified locally that both new `Website` links resolve to the correct landing page in the rendered DOM (alongside the existing EyeBench and OneStop entries)
- [ ] Confirm the live site shows `Website` between `Code` and `Abstract` for both papers after merge

Companion PRs that ship the modernized landing pages:
- lacclab/Open-Ended-Goal-Decoding-Landing#1
- lacclab/Decoding-Reading-Goals-from-Eye-Movements-Landing#1
- lacclab/lacclab.github.io#5